### PR TITLE
Add simple module for DM interaction, set up makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,c
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,c
+
+### C ###
 # Prerequisites
 *.d
 
@@ -50,3 +54,38 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,c

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,13 @@
 *.la
 *.lo
 
+# Module ones
+*.mod
+*.mod.c
+*.mod.o
+*.order
+*.symvers
+
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+
+# To build modules outside of the kernel tree, we run "make"
+# in the kernel source tree; the Makefile these then includes this
+# Makefile once again.
+# This conditional selects whether we are being included from the
+# kernel Makefile or not.
+ifeq ($(KERNELRELEASE),)
+
+    # Assume the source tree is where the running kernel was built
+    # You should set KERNELDIR in the environment if it's elsewhere
+    KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+    # The current directory is passed to sub-makes as argument
+    PWD := $(shell pwd)
+
+modules:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+
+modules_install:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
+
+clean:
+	rm -rf *.o *~ core .depend .*.cmd *.ko *.mod.c .tmp_versions
+
+.PHONY: modules modules_install clean
+
+else
+    # called from kernel build system: just declare what our modules are
+    obj-m := yourfile.o
+endif
+
+
+

--- a/hwprocess/hwprocess.c
+++ b/hwprocess/hwprocess.c
@@ -1,0 +1,20 @@
+#include <linux/init.h>
+#include <linux/module.h>
+MODULE_LICENSE("Dual BSD/GPL");
+
+static int hello_init(void) {
+        printk(KERN_ALERT "Hello, world!\n");
+	printk(KERN_INFO "The current process is \"%s\" (pid %i)\n", current->comm, current->pid);
+	// current->comm - program files name
+	// current->pid - current process id
+	return 0;
+}
+
+static void hello_exit(void) {
+        printk(KERN_ALERT "Bye, world\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);
+// run ps -p #PID to get info about current process
+


### PR DESCRIPTION
Added simple module for interaction with Diagnostic Message Journal, that just prints some message and provides it with PID. 

Set up versatile Makefile that can be used before executing the module (as a prepare point). 

TODO: describe the execute process in README.